### PR TITLE
Update build.rs: Remove ninja build

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -63,7 +63,6 @@ fn build_with_cmake(src_path: &str) {
     }
 
     builder
-        .generator("Ninja")
         .define("BUILD_EXAMPLES", "OFF")
         .define("CMAKE_BUILD_TYPE", "Release")
         // turn off until this is fixed


### PR DESCRIPTION
This seems to also be done already in 4.6.0 bindings but we should do it for this branch also. This fixes issues with people not having `ninja` in their PATH on windows and linux, which has been cropping up causing unnecessary friction and may deter people from trying raylib-rs when things don't just work out of box.

```
  CMake Error: CMake was unable to find a build program corresponding to "Ninja".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
```
https://discord.com/channels/426912293134270465/540620507708522517/1138805729541763082

I tested removing it and it builds fine.