### PR TITLE
Fix building on WASM

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -307,7 +307,7 @@ fn run_command(cmd: &str, args: &[&str]) {
 fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
     let platform = if target.contains("wasm32") {
         // make sure cmake knows that it should bundle glfw in
-        env::set_var("EMCC_CFLAGS", "-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS");
+        env::set_var("EMCC_CFLAGS", "-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sASYNCIFY");
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -307,8 +307,7 @@ fn run_command(cmd: &str, args: &[&str]) {
 fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
     let platform = if target.contains("wasm32") {
         // make sure cmake knows that it should bundle glfw in
-        // Cargo web takes care of this but better safe than sorry
-        env::set_var("EMCC_CFLAGS", "-sUSE_GLFW=3");
+        env::set_var("EMCC_CFLAGS", "-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS");
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -308,7 +308,7 @@ fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
     let platform = if target.contains("wasm32") {
         // make sure cmake knows that it should bundle glfw in
         // Cargo web takes care of this but better safe than sorry
-        env::set_var("EMMAKEN_CFLAGS", "-s USE_GLFW=3");
+        env::set_var("EMCC_FLAGS", "-s USE_GLFW=3");
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -308,7 +308,7 @@ fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
     let platform = if target.contains("wasm32") {
         // make sure cmake knows that it should bundle glfw in
         // Cargo web takes care of this but better safe than sorry
-        env::set_var("EMCC_FLAGS", "-sUSE_GLFW=3");
+        env::set_var("EMCC_CFLAGS", "-sUSE_GLFW=3");
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -308,7 +308,7 @@ fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
     let platform = if target.contains("wasm32") {
         // make sure cmake knows that it should bundle glfw in
         // Cargo web takes care of this but better safe than sorry
-        env::set_var("EMCC_FLAGS", "-s USE_GLFW=3");
+        env::set_var("EMCC_FLAGS", "-sUSE_GLFW=3");
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI


### PR DESCRIPTION
`cargo web` has been unmaintained for three years and the correct build command is now`EMCC_CFLAGS="-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sASYNCIFY" cargo build --release --target=wasm32-unknown-emscripten`. This PR changes build.rs to automate the first three flags.