### PR TITLE
Add binding for `LoadFontFromMemory`

### DIFF
--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1072,13 +1072,13 @@ impl Quaternion {
     }
 
     /// Returns a quaternion equivalent to Euler angles.
-    pub fn from_euler(pitch: f32, yaw: f32, roll: f32) -> Quaternion {
-        let x0 = (pitch * 0.5).cos();
-        let x1 = (pitch * 0.5).sin();
-        let y0 = (yaw * 0.5).cos();
-        let y1 = (yaw * 0.5).sin();
-        let z0 = (roll * 0.5).cos();
-        let z1 = (roll * 0.5).sin();
+    pub fn from_euler(roll: f32, pitch: f32, yaw: f32) -> Quaternion {
+        let x0 = (roll * 0.5).cos();
+        let x1 = (roll * 0.5).sin();
+        let y0 = (pitch * 0.5).cos();
+        let y1 = (pitch * 0.5).sin();
+        let z0 = (yaw * 0.5).cos();
+        let z1 = (yaw * 0.5).sin();
 
         Quaternion {
             x: (x1 * y0 * z0) - (x0 * y1 * z1),

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -152,7 +152,45 @@ impl RaylibHandle {
         }
         Ok(Font(f))
     }
-
+    /// Load font data from a given memory buffer.
+    /// `file_type` refers to the extension, e.g. ".ttf".
+    #[inline]
+    pub fn load_font_from_memory(
+        &mut self,
+        _: &RaylibThread,
+        file_type: &str,
+        file_data: &[u8],
+        font_size: i32,
+        chars: FontLoadEx,
+    ) -> Result<Font, String> {
+        let c_file_type = CString::new(file_type).unwrap();
+        let f = unsafe {
+            match chars {
+                FontLoadEx::Chars(c) => ffi::LoadFontFromMemory(
+                    c_file_type.as_ptr(),
+                    file_data.as_ptr(),
+                    file_data.len() as i32,
+                    font_size,
+                    c.as_ptr() as *mut i32,
+                    c.len() as i32,
+                ),
+                FontLoadEx::Default(count) => ffi::LoadFontFromMemory(
+                    c_file_type.as_ptr(),
+                    file_data.as_ptr(),
+                    file_data.len() as i32,
+                    font_size,
+                    std::ptr::null_mut(),
+                    count,
+                ),
+            }
+        };
+        if f.chars.is_null() || f.texture.id == 0 {
+            return Err(format!(
+                "Error loading font from memory. Is it the right type?"
+            ));
+        }
+        Ok(Font(f))
+    }
     /// Loads font data for further use (see also `Font::from_data`).
     /// Now supports .tiff
     #[inline]


### PR DESCRIPTION
Copy of https://github.com/deltaphc/raylib-rs/pull/153 to be merged into master. The intention here would then be to sync this change into all the branches that have commits ahead of the original raylib-rs.
This is not a change related to updating Raylib, yes, this is being made here because of the state of the original repo.

This should show up on https://github.com/deltaphc/raylib-rs/issues/107 but will not close it.