### PR TITLE
Fix building on WASM 

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -298,7 +298,7 @@ fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
         // make sure cmake knows that it should bundle glfw in
         env::set_var(
             "EMCC_CFLAGS",
-            "-sUSE_GLFW=3 -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap",
+            "-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap",
         );
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -72,7 +72,7 @@ fn build_with_cmake(src_path: &str) {
     // This seems redundant, but I felt it was needed incase raylib changes it's default
     #[cfg(not(feature = "wayland"))]
     builder.define("USE_WAYLAND", "OFF");
-    
+
     // Scope implementing flags for forcing OpenGL version
     // See all possible flags at https://github.com/raysan5/raylib/wiki/CMake-Build-Options
     {
@@ -242,7 +242,7 @@ fn link(platform: Platform, platform_os: PlatformOS) {
         println!("cargo:rustc-link-lib=brcmEGL");
         println!("cargo:rustc-link-lib=brcmGLESv2");
         println!("cargo:rustc-link-lib=vcos");
-   }
+    }
 
     println!("cargo:rustc-link-lib=static=raylib");
 }
@@ -296,8 +296,10 @@ fn run_command(cmd: &str, args: &[&str]) {
 fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
     let platform = if target.contains("wasm32") {
         // make sure cmake knows that it should bundle glfw in
-        // Cargo web takes care of this but better safe than sorry
-        env::set_var("EMMAKEN_CFLAGS", "-s USE_GLFW=3");
+        env::set_var(
+            "EMCC_CFLAGS",
+            "-sUSE_GLFW=3 -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap",
+        );
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1072,13 +1072,13 @@ impl Quaternion {
     }
 
     /// Returns a quaternion equivalent to Euler angles.
-    pub fn from_euler(pitch: f32, yaw: f32, roll: f32) -> Quaternion {
-        let x0 = (pitch * 0.5).cos();
-        let x1 = (pitch * 0.5).sin();
-        let y0 = (yaw * 0.5).cos();
-        let y1 = (yaw * 0.5).sin();
-        let z0 = (roll * 0.5).cos();
-        let z1 = (roll * 0.5).sin();
+    pub fn from_euler(roll: f32, pitch: f32, yaw: f32) -> Quaternion {
+        let x0 = (roll * 0.5).cos();
+        let x1 = (roll * 0.5).sin();
+        let y0 = (pitch * 0.5).cos();
+        let y1 = (pitch * 0.5).sin();
+        let z0 = (yaw * 0.5).cos();
+        let z1 = (yaw * 0.5).sin();
 
         Quaternion {
             x: (x1 * y0 * z0) - (x0 * y1 * z1),


### PR DESCRIPTION
Replacment for https://github.com/bitten2up/raylib-rs/pull/7 which 
- merges to master instead so that this change can be more easily propagated into the other branches. This is once again a general change, being made here due to the state of the original repo.
- Adds the rest of the `-s` commands that Raylib recommends, sourced from https://github.com/ryupold/examples-raylib.zig/blob/main/build.zig

Original PR description:
> `cargo web` has been unmaintained for three years and the correct build command is now`EMCC_CFLAGS="-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sASYNCIFY" cargo build --release --target=wasm32-unknown-emscripten`. This PR changes build.rs to automate the first three flags.